### PR TITLE
Looser gemspec requirements, so lingohub plays nice with other gems

### DIFF
--- a/lingohub.gemspec
+++ b/lingohub.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[lib]
   gem.files = Dir['{lib}/**/*.rb', 'bin/*', 'LICENSE', '*.md']
 
-  gem.add_dependency('rest-client', '2.0.2')
-  gem.add_dependency('launchy', '2.4.3')
-  gem.add_dependency('stringex', '2.7.1')
+  gem.add_dependency('rest-client', '>= 1.6.7', '< 3.0.0')
+  gem.add_dependency('launchy', '~> 2.0')
+  gem.add_dependency('stringex', '>= 1.3.2', '< 3.0.0')
 
   # gem.add_development_dependency('rake',    '~> 0.9.2')
   # gem.add_development_dependency('rspec',   '~> 2.8.0')


### PR DESCRIPTION
Currently, 0.5.0 specifies exact versions of its runtime requirements. That makes it incompatible with any gems that don't have those specific versions in their range, and locks integrators to those specific versions - if/when they want to upgrade (e.g., if a security vulnerability was found in one of them), they'll need to wait for an update to the lingohub gem to do so.

Best practice in Ruby is to specify ranges in the gemspec, either using the `~>` specifier or range requirement specifiers. I've updated the gemspec here to do that, and based the lower bounds on https://github.com/lingohub/lingohub_ruby/commit/05223f825fda3cedaf3cdea7a14a751811bd0aa4 (since there have been no code changes since then we can be confident they work).

Would be awesome if you could push a v0.5.1 with these changes - would allow a lot of people to upgrade who've previously been stuck on v0.4.1.