### PR TITLE
Added --directory option to resource upload

### DIFF
--- a/lib/lingohub/commands/help.rb
+++ b/lib/lingohub/commands/help.rb
@@ -53,14 +53,14 @@ module Lingohub::Command
         group.command 'resource:down --locale <iso2_code> --all --directory <path> --project <name>',                     'download all resource files, using the given locale as filter'
         group.command 'resource:down <file1> <file2> ... --directory <path> --project <name>',                            'download specific resource files'
 
-        up_command = 'resource:up <file1> <file2> ... --locale <iso2_code> --project <name>'
+        up_command = 'resource:up <file1> <file2> ... --locale <iso2_code> --project <name> --directory <path>'
 
         strategy_desc = ""
         Lingohub::Command::Resource::EXPECTED_STRATEGY_PARAMETERS.each do |parameter|
           strategy_desc << " --#{parameter} true|false"
         end
 
-        group.command "resource:up <file1> <file2> ... --locale <iso2_code> --project <name> [#{strategy_desc}]",          "upload specific resource files, a locale may be specified to tell lingohub the locale of file content"
+        group.command "resource:up <file1> <file2> ... --locale <iso2_code> --project <name> --directory <path> [#{strategy_desc}]",          "upload specific resource files, a locale may be specified to tell lingohub the locale of file content"
         group.space
       end
     end

--- a/lib/lingohub/commands/resource.rb
+++ b/lib/lingohub/commands/resource.rb
@@ -99,10 +99,11 @@ module Lingohub::Command
     end
 
     def upload_resources(resources)
+      directory = extract_option('--directory')
       resources.each do |file_name|
         begin
           path = File.expand_path(file_name, Dir.pwd)
-          project.upload_resource(path, extract_locale_from_args, extract_strategy_parameters)
+          project.upload_resource(path, extract_locale_from_args, extract_strategy_parameters, directory)
           display("#{file_name} uploaded")
         rescue
           display "Error uploading #{file_name}. Response: #{$!.message || $!.response}"

--- a/lib/lingohub/models/project.rb
+++ b/lib/lingohub/models/project.rb
@@ -50,10 +50,11 @@ module Lingohub
         end
       end
 
-      def upload_resource(path, locale, strategy_parameters = {})
+      def upload_resource(path, locale, strategy_parameters = {}, directory)
         raise "Path #{path} does not exists" unless File.exists?(path)
         request = { :file => File.new(path, "rb") }
         request.merge!({ :iso2_slug => locale }) if locale
+        request.merge!({ :path => directory }) if directory
         request.merge!(strategy_parameters)
         @client.post(self.resources_url, request)
       end


### PR DESCRIPTION
This option allows to define a path when uploading files as specified in the [API documentation](https://lingohub.com/documentation/developers/api-v1/upload-file/).